### PR TITLE
replaced the deprecated import

### DIFF
--- a/webviz_plugin_boilerplate/plugins/_some_custom_plugin.py
+++ b/webviz_plugin_boilerplate/plugins/_some_custom_plugin.py
@@ -1,4 +1,4 @@
-import dash_html_components as html
+from dash import html
 from webviz_config import WebvizPluginABC
 
 


### PR DESCRIPTION
The dash_html_components package is deprecated. Replaced
`import dash_html_components as html` with `from dash import html`