### PR TITLE
`callback` no longer accessed via `app` but directly imported from Dash

### DIFF
--- a/webviz_plugin_boilerplate/plugins/_some_other_custom_plugin.py
+++ b/webviz_plugin_boilerplate/plugins/_some_other_custom_plugin.py
@@ -1,19 +1,20 @@
 from uuid import uuid4
 
+from dash import callback
 import dash_html_components as html
 from dash.dependencies import Input, Output
 from webviz_config import WebvizPluginABC
 
 
 class SomeOtherCustomPlugin(WebvizPluginABC):
-    def __init__(self, app):
+    def __init__(self):
 
         super().__init__()
 
         self.button_id = f"submit-button-{uuid4()}"
         self.div_id = f"output-state-{uuid4()}"
 
-        self.set_callbacks(app)
+        self.set_callbacks()
 
     @property
     def layout(self):
@@ -25,8 +26,8 @@ class SomeOtherCustomPlugin(WebvizPluginABC):
             ]
         )
 
-    def set_callbacks(self, app):
-        @app.callback(
+    def set_callbacks(self):
+        @callback(
             Output(self.div_id, "children"), [Input(self.button_id, "n_clicks")]
         )
         def _update_output(n_clicks):

--- a/webviz_plugin_boilerplate/plugins/best_practice_plugin/_callbacks.py
+++ b/webviz_plugin_boilerplate/plugins/best_practice_plugin/_callbacks.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from dash import Dash, Input, Output, no_update
+from dash import callback, Input, Output, no_update
 from dash.exceptions import PreventUpdate
 
 
@@ -33,8 +33,8 @@ from ._property_serialization import (
 ###########################################################################
 
 
-def plugin_callbacks(app: Dash, get_uuid: Callable, graph_data_model: GraphDataModel):
-    @app.callback(
+def plugin_callbacks(get_uuid: Callable, graph_data_model: GraphDataModel):
+    @callback(
         Output(get_uuid(LayoutElements.GRAPH), "figure"),
         [
             Input(get_uuid(LayoutElements.GRAPH_SELECTION_DROPDOWN), "value"),

--- a/webviz_plugin_boilerplate/plugins/best_practice_plugin/_plugin.py
+++ b/webviz_plugin_boilerplate/plugins/best_practice_plugin/_plugin.py
@@ -2,7 +2,6 @@ from typing import Union, Type
 
 from webviz_config import WebvizPluginABC
 
-from dash import Dash
 from dash.development.base_component import Component
 
 from ._business_logic import GraphDataModel
@@ -41,13 +40,13 @@ class BestPracticePlugin(WebvizPluginABC):
     for Dash callback Output property by use of data from business logic.
     """
 
-    def __init__(self, app: Dash) -> None:
+    def __init__(self) -> None:
         super().__init__()
 
         self._graph_data_model = GraphDataModel()
         self._graph_data_model.populate_with_mock_data()
 
-        self.set_callbacks(app)
+        self.set_callbacks()
 
     @property
     def layout(self) -> Union[str, Type[Component]]:
@@ -56,5 +55,5 @@ class BestPracticePlugin(WebvizPluginABC):
             graph_names=self._graph_data_model.graph_set().graph_names(),
         )
 
-    def set_callbacks(self, app) -> None:
-        plugin_callbacks(app, self.uuid, self._graph_data_model)
+    def set_callbacks(self) -> None:
+        plugin_callbacks(self.uuid, self._graph_data_model)


### PR DESCRIPTION
According to https://dash.plotly.com/dash-2-0-migration#@dash.callback, `callback` does no longer need to be accessed via `dash` object but can be imported directly.