### PR TITLE
Bump minor Python version to 3.8

### DIFF
--- a/.github/workflows/webviz-plugin-boilerplate.yml
+++ b/.github/workflows/webviz-plugin-boilerplate.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - name: 📖 Checkout commit locally

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/equinor/webviz-plugin-boilerplate/workflows/webviz-plugin-boilerplate/badge.svg)](https://github.com/equinor/webviz-plugin-boilerplate/actions?query=branch%3Amaster)
-[![Python 3.6 | 3.7 | 3.8](https://img.shields.io/badge/python-3.6%20|%203.7%20|%203.8%20|%203.9-blue.svg)](https://www.python.org/)
+[![Python 3.8 | 3.9 | 3.10](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org/)
 
 # Quickly get started creating plugins to `webviz-config`
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     tests_require=TESTS_REQUIRE,
     extras_require={"tests": TESTS_REQUIRE},
     setup_requires=["setuptools_scm~=3.2"],
-    python_requires="~=3.6",
+    python_requires="~=3.8",
     use_scm_version=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Remove support for Python 3.6 and 3.7 in accordance to supported versions in [`webviz-config`](https://github.com/equinor/webviz-config) and [`webviz-core-components`](https://github.com/equinor/webviz-core-components).

Closes: https://github.com/equinor/webviz-plugin-boilerplate/issues/26